### PR TITLE
Improve contrast for statusBar.debuggingBackground

### DIFF
--- a/themes/The-Best-Theme-color-theme.json
+++ b/themes/The-Best-Theme-color-theme.json
@@ -349,7 +349,7 @@
     "statusBar.background": "#0d1114",
     "statusBar.foreground": "#cccccc",
     "statusBar.border": "#0000",
-    "statusBar.debuggingBackground": "#cc5522",
+    "statusBar.debuggingBackground": "#a33107",
     "statusBar.debuggingForeground": "#ffffff",
     "statusBar.debuggingBorder": "#0000",
     "statusBar.noFolderForeground": "#cccccc",


### PR DESCRIPTION
# Original (Before fix for #4)

https://contrast-ratio.com/#%23cccccc-on-%23cc6633

![image](https://user-images.githubusercontent.com/22199259/125191554-aea94a00-e260-11eb-96fc-748b4be5bf3a.png)

# The current version as per https://github.com/jankohlbach/the-best-theme/commit/d470a256d1539bbd723963a9021ef8788080f64d

https://contrast-ratio.com/#%23fff-on-%23cc5522

![image](https://user-images.githubusercontent.com/22199259/125191563-bcf76600-e260-11eb-96dc-7476e119598e.png)

# My change (This PR)

https://contrast-ratio.com/#%23ffffff-on-%23A33107

![image](https://user-images.githubusercontent.com/22199259/125191581-d7c9da80-e260-11eb-968c-82adb2304257.png)

